### PR TITLE
Adds 2 makefile targets for release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,15 @@ test: virtualenv
 functional-test:
 	@bundletester
 
+release: check-path
+	@.venv/bin/pip install git-vendor
+	@.venv/bin/git-vendor sync -d $KUBERNETES_MASTER_BZR
+
+check-path:
+ifndef KUBERNETES_MASTER_BZR
+	$(error KUBERNETES_MASTER_BZR is undefined)
+endif
+
 clean:
 	rm -rf .venv
 	find -name *.pyc -delete


### PR DESCRIPTION
```
`check-path` will sniff the ENV for $KUBERNETES_MASTER_BZR envvar. If it
is not found, it will not allow the release process to continue.

`make release` will kick off the release process of installing the
git-vendor python module, and passing off the $KUBERNETES_MASTER_BZR env
location to git-vendor. *note* the constraints of git-vendor still
apply. The repository must have a tag to export and cannot be in a dirty
state.

This is CI-capable so long as CI doesn't alter any files in the
repository prior to "blessing" a release. At which point, we can
automate the release process by setting the ENVVAR for the job.
```
