### PR TITLE
Adding double tack to the upstart templates

### DIFF
--- a/files/apiserver.upstart.tmpl
+++ b/files/apiserver.upstart.tmpl
@@ -8,10 +8,10 @@ limit nofile 20000 20000
 kill timeout 30 # wait 30s between SIGTERM and SIGKILL.
 
 exec /usr/local/bin/apiserver \
-     -address=%(api_bind_address)s \
-     -etcd_servers=%(etcd_servers)s \
-     -logtostderr=true \
-     -portal_net=10.244.240.0/20
+     --address=%(api_bind_address)s \
+     --etcd_servers=%(etcd_servers)s \
+     --logtostderr=true \
+     --portal_net=10.244.240.0/20
 
 
 

--- a/files/controller-manager.upstart.tmpl
+++ b/files/controller-manager.upstart.tmpl
@@ -8,9 +8,9 @@ limit nofile 20000 20000
 kill timeout 30 # wait 30s between SIGTERM and SIGKILL.
 
 exec /usr/local/bin/controller-manager \
-     -address=%(bind_address)s \
-     -logtostderr=true \
-     -master=%(api_server_address)s
+     --address=%(bind_address)s \
+     --logtostderr=true \
+     --master=%(api_server_address)s
 
 
 

--- a/files/scheduler.upstart.tmpl
+++ b/files/scheduler.upstart.tmpl
@@ -8,9 +8,9 @@ limit nofile 20000 20000
 kill timeout 30 # wait 30s between SIGTERM and SIGKILL.
 
 exec /usr/local/bin/scheduler \
-     -address=%(bind_address)s \
-     -logtostderr=true \
-     -master=%(api_server_address)s
+     --address=%(bind_address)s \
+     --logtostderr=true \
+     --master=%(api_server_address)s
 
 
 


### PR DESCRIPTION
Testing revealed that the old upstart templates do not work with current versions of kubernetes.  We found the older docs listed these arguments with single tack (-) and that was likely the reason the original upstart scripts had arguments with single tacks. 

I added double tack arguments tot he upstart scripts and deployed kubernetes v0.8.1 (our default version) and everything worked, so this pull request is suggesting we move to using double tacks everywhere as not to break current versions of kubernetes.
