### PR TITLE
Includes a concept e2e action to fire off and run the end to end testing

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,2 @@
+e2e:
+    description: Kicks off the end to end tests for Kubernetes

--- a/actions/e2e
+++ b/actions/e2e
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. /root/.bashrc
+
+/opt/kubernetes/_output/local/bin/linux/amd64/e2e --host="$KUBERNETES_MASTER"


### PR DESCRIPTION
of the kubernetes bundle, for verification of proper cluster setup.

to run this you will at bare minimum need juju 1.22, and have the proper
feature flag exported. Otherwise use 1.23-beta (at time of current
writing) so this feature is enabled by default

```
juju action do kubernetes-master/0 e2e
```

This will queue the action, and you can receive the status from the
command

```
juju action status
juju action get <uuid>
```
