### PR TITLE
charm-helpers being embedded is no longer desired.

### DIFF
--- a/charm-helpers.yaml
+++ b/charm-helpers.yaml
@@ -1,5 +1,0 @@
-destination: hooks/charmhelpers
-branch: lp:charmhelpers
-include:
-  - core
-  - fetch


### PR DESCRIPTION
The charm has been refactored to install charm-helpers from pip. This
relic can safely be removed, with my flamenwerfer, that werfs flamen.
